### PR TITLE
lxc changed to lxd-installer

### DIFF
--- a/marvel-snap-deck-tracker-ubuntu.sh
+++ b/marvel-snap-deck-tracker-ubuntu.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSION="1.1.0"
+VERSION="1.1.1"
 
 SCRIPT_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 SCRIPT_FILE=$(basename $BASH_SOURCE)

--- a/marvel-snap-deck-tracker-ubuntu.sh
+++ b/marvel-snap-deck-tracker-ubuntu.sh
@@ -33,7 +33,7 @@ echo ""
 title "Updating apt sources:"
 apt update
 
-apt-install lxc
+apt-install lxd-installer
 
 echo ""
 title "Setting up the LXC/LXD container:"    


### PR DESCRIPTION
LXC/LXD is a prerequisite to use the builder. Now, `lxd-installer` instead of `lxc` will be used in order to install the prerequisite, which make the builder compatible with Ubuntu 22.10 (and still compatible with 22.04 LTS).